### PR TITLE
pinning setuptools to < 70

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,95 @@
+name: Docker
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on:
+  # schedule:
+  #   - cron: '27 18 * * *'
+  push:
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # Install the cosign tool except on PR
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@v3.3.0
+        with:
+          cosign-release: 'v2.2.2' # optional
+
+      # Set up BuildKit Docker container builder to be able to build
+      # multi-platform images and export cache
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
+          TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.build-and-push.outputs.digest }}
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+FROM mambaorg/micromamba:latest
+
+RUN micromamba install -y -n base -c conda-forge git && \
+    micromamba clean --all --yes
+
+# Install mamba from conda-forge (now without defaults)
+RUN micromamba install -y mamba -n base -c conda-forge && \
+    micromamba clean -afy
+
+# Clone mbarq
+WORKDIR /home/mambauser
+ENV MAMBA_ROOT_PREFIX=/opt/conda
+ENV PATH=${MAMBA_ROOT_PREFIX}/bin:${PATH}
+RUN git clone https://github.com/MicrobiologyETHZ/mbarq.git
+WORKDIR /home/mambauser/mbarq
+
+# Use bash so 'conda' works as expected in RUN steps
+SHELL ["/bin/bash", "-c"]
+
+# Create env and install mbarq
+# RUN micromamba env create -f mbarq_environment.yaml && \
+#     source activate mbarq && \
+#     pip install -e . && \
+#     conda clean -afy
+RUN micromamba env create -f mbarq_environment.yaml && \
+    micromamba run -n mbarq pip install -e . && \ 
+    micromamba clean --all --yes
+
+RUN micromamba run -n mbarq pip install 'setuptools<=70'
+
+# Make the mbarq env default on PATH
+ENV PATH=/opt/conda/envs/mbarq/bin:${PATH}
+
+# Sanity check: fail build if mbarq is not callable
+RUN mbarq --help >/dev/null
+
+
+ENTRYPOINT ["/bin/bash"]
+CMD []

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
 FROM mambaorg/micromamba:latest
 
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends procps && \
+    rm -rf /var/lib/apt/lists/*
+
+USER $MAMBA_USER
+
 RUN micromamba install -y -n base -c conda-forge git && \
     micromamba clean --all --yes
 

--- a/mbarq_environment.yaml
+++ b/mbarq_environment.yaml
@@ -2,20 +2,22 @@ name: mbarq
 channels:
   - bioconda
   - conda-forge
-  - defaults
 dependencies:
   - mageck
-  - python>=3.8
+  - python==3.8.*
   - blast==2.9.*
   - bedtools==2.30.*
   - biopython==1.79
-  - numpy=1.22
-  - pandas
+  - numpy=1.22.1
+  - pandas==1.3.3
   - pytest
   - click
-  - pip
   - pandera
   - pyranges==0.0.117
   - pybedtools == 0.9.0
   - setuptools<=70
+  - pip
+  - pip:
+      - "--editable=git+https://github.com/MicrobiologyETHZ/mbarq#egg=mbarq"
+
 

--- a/mbarq_environment.yaml
+++ b/mbarq_environment.yaml
@@ -17,4 +17,5 @@ dependencies:
   - pandera
   - pyranges==0.0.117
   - pybedtools == 0.9.0
+  - setuptools<=70
 

--- a/mbarq_environment.yaml
+++ b/mbarq_environment.yaml
@@ -4,12 +4,12 @@ channels:
   - conda-forge
 dependencies:
   - mageck
-  - python==3.8.*
+  - python==3.10
   - blast==2.9.*
   - bedtools==2.30.*
   - biopython==1.79
-  - numpy=1.22.1
-  - pandas==1.3.3
+  - numpy
+  - pandas
   - pytest
   - click
   - pandera
@@ -17,7 +17,4 @@ dependencies:
   - pybedtools == 0.9.0
   - setuptools<=70
   - pip
-  - pip:
-      - "--editable=git+https://github.com/MicrobiologyETHZ/mbarq#egg=mbarq"
-
 


### PR DESCRIPTION
Hi Anna,

the current commit fails to provide a functional install - after following install instructions then `mbarq --help` fails with

```
Traceback (most recent call last):
  File "/g/typas/Personal_Folders/Nic/miniforge3/envs/mbarq/bin/mbarq", line 3, in <module>
    from mbarq.cli import main
  File "/g/typas/Personal_Folders/Nic/miniforge3/envs/mbarq/lib/python3.10/site-packages/mbarq/cli.py", line 7, in <module>
    from mbarq.mapper import Mapper, AnnotatedMap
  File "/g/typas/Personal_Folders/Nic/miniforge3/envs/mbarq/lib/python3.10/site-packages/mbarq/mapper.py", line 12, in <module>
    import pyranges as pr
  File "/g/typas/Personal_Folders/Nic/miniforge3/envs/mbarq/lib/python3.10/site-packages/pyranges/__init__.py", line 18, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```

(Tried on our HPC).

Fixing the setuptools to an older version fixes it (seems `pkg_resources` is no longer being used/provided by modern `setuptools`)

Addition of 2nd commit: Adding a docker build file; removing defaults channel from `mbarq_environment.yaml`, few other minor version changes